### PR TITLE
local/maillog Pass PHPUnit tests on Totara 13

### DIFF
--- a/rb_sources/lang/en/rb_source_maillog.php
+++ b/rb_sources/lang/en/rb_source_maillog.php
@@ -1,6 +1,7 @@
 <?php
 
 $string['sourcetitle'] = 'Mail log';
+$string['sourcelabel'] = 'Mail log';
 $string['attachname'] = 'Attachment name';
 $string['logid'] = 'Log ID';
 $string['messagetext'] = 'Message text';

--- a/rb_sources/rb_source_maillog.php
+++ b/rb_sources/rb_source_maillog.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Totara LMS
  *
@@ -54,6 +55,7 @@ class rb_source_maillog extends rb_base_source {
         $this->defaultfilters = $this->define_defaultfilters();
         $this->requiredcolumns = $this->define_requiredcolumns();
         $this->sourcetitle = get_string('sourcetitle', 'rb_source_maillog');
+        $this->sourcelabel = get_string('sourcelabel', 'rb_source_maillog');
         $this->usedcomponents[] = 'local_maillog';
 
         parent::__construct();

--- a/reportbuilder/embedded/rb_local_maillog_mailqueue_embedded.php
+++ b/reportbuilder/embedded/rb_local_maillog_mailqueue_embedded.php
@@ -23,7 +23,7 @@
  */
 
 global $CFG;
-require_once($CFG->dirroot.'/totara/reportbuilder/classes/rb_base_content.php');
+require_once($CFG->dirroot.'/totara/reportbuilder/classes/rb/content/base.php');
 require_once($CFG->dirroot.'/local/maillog/classes/helper.php');  // so we can use the consts.
 
 class rb_local_maillog_mailqueue_embedded extends rb_base_embedded {


### PR DESCRIPTION
WR322927 Due to changes between Totara 12 and Totara 13,
these changes are required of the local_maillog plugin.

modified:   rb_sources/lang/en/rb_source_maillog.php
modified:   rb_sources/rb_source_maillog.php
modified:   reportbuilder/embedded/rb_local_maillog_mailqueue_embedded.php