### PR TITLE
local_maillog feature: Notification of queuemails setting.

### DIFF
--- a/lang/en/local_maillog.php
+++ b/lang/en/local_maillog.php
@@ -26,3 +26,5 @@ $string['type_maillog'] = 'Mail log';
 $string['task:purgelog'] = 'Purge mail log';
 $string['task:sendscheduled'] = 'Send scheduled emails';
 $string['withselected'] = 'With selected:';
+$string['critical'] = 'CRITICAL: Queue emails switched on. Hours passed: {$a->hourspassed} (Checked {$a->now})';
+

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mail log plugin by Catalyst IT.
+ * Update Moodle user bounce counts and delete mail message
+ * Delete old bounce messages
+ * Expunge
+ *
+ * @package local_maillog
+ * @author  Sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @copyright 2013 onwards Catalyst IT Ltd
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Records the date of the last update to queuemails admin setting.
+ *
+ * @return void
+ */
+function local_maillog_notify() {
+    // Add time when the queuemails setting is updated.
+    set_config('queuemailsdate', time(), 'local_maillog');
+}

--- a/notify.php
+++ b/notify.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mail log plugin by Catalyst IT.
+ * Notifies if the setting of queuemails is switched on.
+ *
+ * @package local_maillog
+ * @author  Sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @copyright 2013 onwards Catalyst IT Ltd
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('NO_UPGRADE_CHECK', true);
+require(__DIR__ . '/../../config.php');
+header("Content-Type: text/plain");
+header('Pragma: no-cache');
+header('Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate, proxy-revalidate');
+header('Expires: Tue, 04 Sep 2012 05:32:29 GMT');
+$format = '%b %d %H:%M:%S';
+$now = userdate(time(), $format);
+$queuemails = get_config('local_maillog', 'queuemails');
+if ($queuemails) {
+    $queuemailsdate = get_config('local_maillog', 'queuemailsdate');
+    $a = new stdClass();
+    $a->hourspassed = round((time() - $queuemailsdate) / 3600);
+    $a->now = $now;
+    printf (get_string('critical', 'local_maillog', $a));
+
+} else {
+    printf ("OK");
+}
+
+
+
+

--- a/settings.php
+++ b/settings.php
@@ -2,17 +2,27 @@
 defined('MOODLE_INTERNAL') || die;
 
 if ($hassiteconfig) { // needs this condition or there is error on login page
-    $settings = new admin_settingpage('local_maillog', 'Mail log');
-    $ADMIN->add('localplugins', $settings);
 
-    $settings->add(new admin_setting_configcheckbox('local_maillog/logmails', get_string('logmails', 'local_maillog'), get_string('configlogmails', 'local_maillog'), 1));
+    $ADMIN->add('localplugins', new admin_category('local_maillog_settings', new lang_string('pluginname', 'local_maillog')));
+    $settingspage = new admin_settingpage('managelocalmaillog', new lang_string('pluginname', 'local_maillog'));
 
-    $settings->add(new admin_setting_configcheckbox('local_maillog/queuemails', get_string('queuemails', 'local_maillog'), get_string('configqueuemails', 'local_maillog', $CFG->wwwroot.'/local/maillog/mailqueue.php'), 0));
+    if ($ADMIN->fulltree) {
+        require_once "$CFG->dirroot/local/maillog/lib.php";
 
+        $settingspage->add(new admin_setting_configcheckbox('local_maillog/logmails', get_string('logmails', 'local_maillog'), get_string('configlogmails', 'local_maillog'), 1));
 
-    $daysoptions = range(1, 30);
-    $daysoptions = array_combine(array_values($daysoptions), $daysoptions);  // fix index
-    $settings->add(new admin_setting_configselect('local_maillog/maxdays',
-        new lang_string('maxdays', 'local_maillog'), new lang_string('maxdaysinfo', 'local_maillog'), 7, $daysoptions));
+        $setting = new admin_setting_configcheckbox('local_maillog/queuemails',
+            get_string('queuemails', 'local_maillog'), get_string('configqueuemails', 'local_maillog', $CFG->wwwroot.'/local/maillog/mailqueue.php'), 0);
+        $setting->set_updatedcallback('local_maillog_notify');
+        $settingspage->add($setting);
+
+        $daysoptions = range(1, 30);
+        $daysoptions = array_combine(array_values($daysoptions), $daysoptions);  // fix index
+        $settingspage->add(new admin_setting_configselect('local_maillog/maxdays',
+            new lang_string('maxdays', 'local_maillog'), new lang_string('maxdaysinfo', 'local_maillog'), 7, $daysoptions));
+    }
+
+    $ADMIN->add('localplugins', $settingspage);
+
 }
 

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 20190317100;
+$plugin->version   = 20190317101;
 $plugin->requires  = 2017051509;
 $plugin->cron      = 0;
 $plugin->component = 'local_maillog';


### PR DESCRIPTION
A page is created to show the queuemails setting status. 