### PR TITLE
Totara 13 stable version format

### DIFF
--- a/version.php
+++ b/version.php
@@ -1,4 +1,18 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * @package   local_maillog
@@ -7,11 +21,15 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version   = 20190317101;
+if (defined('MOODLE_INTERNAL')) {
+    if (get_config('local_maillog', 'version') == '20190317101') {
+        set_config('version', '2022082600', 'local_maillog');
+    }
+}
+$plugin->version   = 2022082600;
 $plugin->requires  = 2017051509;
 $plugin->cron      = 0;
 $plugin->component = 'local_maillog';
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->release   = 'ALPHA';
+


### PR DESCRIPTION
Fixes the 'version number for Totara branches is 11 chars as oppose to the usual 10' issue.