### PR TITLE
Fixes for T17 - The breadcrumb link is not working for mailqueue page

### DIFF
--- a/mailqueue.php
+++ b/mailqueue.php
@@ -87,7 +87,7 @@ $PAGE->requires->js_init_call('M.local_maillog_mailqueue.init', array(), false, 
 ///
 /// Display the page
 ///
-$PAGE->navbar->add(get_string('pluginname', 'local_maillog'), new moodle_url('/admin/settings.php', array('section' => 'local_maillog')));
+$PAGE->navbar->add(get_string('pluginname', 'local_maillog'), new moodle_url('/admin/settings.php', array('section' => 'managelocalmaillog')));
 $PAGE->navbar->add($strheading);
 
 $PAGE->set_title($strheading);


### PR DESCRIPTION
Given you are viewing the mail queue report on "local/maillog/mailqueue.php"
And click on "Mail log" in the breadcrumb 
Then you get a section error.
 
I assume the section name is now different, this patch fixed my env, so decided to create a PR for the latest Totara branch.