### PR TITLE
Replace deprecated get_default_table_aliases with get_default_tables

### DIFF
--- a/classes/local/entities/maillog.php
+++ b/classes/local/entities/maillog.php
@@ -35,15 +35,16 @@ class maillog extends base {
     /**
      * Database tables that this entity uses
      *
-     * @return array
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'mail_log' => 'ml',
-            'user' => 'u',
-            'course' => 'c',
+            'mail_log',
+            'user',
+            'course',
         ];
     }
+
     /**
      * The default title for this entity
      *


### PR DESCRIPTION
Hi 
It will fix get_default_table_aliases() is deprecated, please define the entity tables with get_default_tables() in local_maillog\local\entities\maillog
