### PR TITLE
Log emails checkbox in settings - Update lang string 

### DIFF
--- a/lang/en/local_maillog.php
+++ b/lang/en/local_maillog.php
@@ -1,7 +1,7 @@
 <?php
 
 $string['pluginname'] = 'Mail log';
-$string['configlogmails'] = 'Log all sent emails. Emails will be kept for 3 months.';
+$string['configlogmails'] = 'Log all sent emails';
 $string['configqueuemails'] = 'Rather than sending out emails, queue emails for approval prior to sending out. <b>NOTE:</b> You must have logging enabled too, if you want to use this feature.<br><b><a href="{$a}">View queue here</a></b>';
 $string['confirmqueuedelete'] = 'Are you sure you want to remove the items from the queue?';
 $string['confirmqueuesend'] = 'Are you sure you want to send these queued items?';


### PR DESCRIPTION
This branch contains a change for Totara 17. Moodle 4.1 branch was updated earlier.

There are 2 settings:
1) `logmails` Log emails
2) `maxdays` Max days to keep emails in log/queue

`maxdays` can be set between 1-30 days, 7 days by default
* https://github.com/catalyst/moodle-local_maillog/blob/TOTARA_17_STABLE/settings.php#L19-L22

`logmails` text should be consistent with the available `maxdays` range.

TOTARA
<img width="1218" height="499" alt="TOTARA_17_STABLE" src="https://github.com/user-attachments/assets/c9294582-7fb2-44c1-a0e8-5b306e58af8a" />

MOODLE
<img width="1516" height="398" alt="MOODLE_405_STABLE" src="https://github.com/user-attachments/assets/8228f404-33ee-4ebb-a89a-7747544de27a" />



